### PR TITLE
Added out of the box support for IE 11.

### DIFF
--- a/src/PageTransition.js
+++ b/src/PageTransition.js
@@ -198,11 +198,11 @@ class PageTransition extends React.Component {
     const { timeout, loadingComponent, loadingCallbackName } = this.props
     const { renderedChildren: children, state } = this.state
 
-    if (['entering', 'exiting', 'exited'].includes(state)) {
+    if (['entering', 'exiting', 'exited'].indexOf(state) !== -1) {
       // Need to reflow!
       // eslint-disable-next-line no-unused-expressions
-      if (document.body) document.body.scrollTop
-    }
+      if (document.body) document.body.scrollTop;
+     }
 
     const hasLoadingComponent = !!loadingComponent
     const containerClassName = buildClassName(this.props.classNames, state)

--- a/src/PageTransition.js
+++ b/src/PageTransition.js
@@ -201,8 +201,8 @@ class PageTransition extends React.Component {
     if (['entering', 'exiting', 'exited'].indexOf(state) !== -1) {
       // Need to reflow!
       // eslint-disable-next-line no-unused-expressions
-      if (document.body) document.body.scrollTop;
-     }
+      if (document.body) document.body.scrollTop
+    }
 
     const hasLoadingComponent = !!loadingComponent
     const containerClassName = buildClassName(this.props.classNames, state)


### PR DESCRIPTION
This line was throwing an error at page load on Internet Explorer 11, transpiled it down to code that ie11 can read. I've done some tests, and it appears to be working properly across all browsers (ie11+) now. 