### PR TITLE
Fix issue with Node production environment and react-transition-group's PropTypes

### DIFF
--- a/src/PageTransition.js
+++ b/src/PageTransition.js
@@ -254,8 +254,10 @@ PageTransition.propTypes = {
   /* eslint-disable react/require-default-props */
   loadingTimeout: (props, ...args) => {
     let pt = timeoutsShape
-    if (props.loadingComponent && process.env.NODE_ENV !== "production") pt = pt.isRequired
-    return pt(props, ...args)
+    if (props.loadingComponent && process.env.NODE_ENV !== "production"){
+      pt = pt.isRequired
+      return pt(props, ...args)
+    }
   },
   loadingClassNames: (props, ...args) => {
     let pt = PropTypes.string

--- a/src/PageTransition.js
+++ b/src/PageTransition.js
@@ -247,14 +247,14 @@ class PageTransition extends React.Component {
 PageTransition.propTypes = {
   children: PropTypes.node.isRequired,
   classNames: PropTypes.string.isRequired,
-  timeout: timeoutsShape.isRequired,
+  timeout: process.env.NODE_ENV !== "production" ? timeoutsShape.isRequired : null,
   loadingComponent: PropTypes.element,
   loadingDelay: PropTypes.number,
   loadingCallbackName: PropTypes.string,
   /* eslint-disable react/require-default-props */
   loadingTimeout: (props, ...args) => {
     let pt = timeoutsShape
-    if (props.loadingComponent) pt = pt.isRequired
+    if (props.loadingComponent && process.env.NODE_ENV !== "production") pt = pt.isRequired
     return pt(props, ...args)
   },
   loadingClassNames: (props, ...args) => {


### PR DESCRIPTION
This is my fix to a known issue, described below.

react-transition-group's custom PropTypes are set to null if the Node env is set to "production."  This causes an Internal Server Error in Next.js, "Cannot read property 'isRequired' of null." 

To fix this, I simply mirrored the react-transition-group's code by nullifying the prop type `timeoutsShape` only if `process.env.NODE_ENV` is `"production"`.

With this fix, the PropType will still be applied in development and create the appropriate console errors.