### PR TITLE
fix: monkeyPatchScrolling to scroll back to top during transitions

### DIFF
--- a/src/PageTransition.js
+++ b/src/PageTransition.js
@@ -191,15 +191,22 @@ class PageTransition extends React.Component {
 
     // It's safe to reenable scrolling now
     this.disableScrolling = false
-    this.setState({
-      state: 'enter',
-      showLoading: false,
-    }, () => {
-      if (this.scrollToArgs && monkeyPatchScrolling && typeof window !== 'undefined') {
-        window.scrollTo(...this.scrollToArgs)
-        this.scrollToArgs = null
+    this.setState(
+      {
+        state: 'enter',
+        showLoading: false,
+      },
+      () => {
+        if (
+          this.scrollToArgs &&
+          monkeyPatchScrolling &&
+          typeof window !== 'undefined'
+        ) {
+          window.scrollTo(...this.scrollToArgs)
+          this.scrollToArgs = null
+        }
       }
-    })
+    )
   }
 
   onEntering = makeStateUpdater('entering').bind(this)

--- a/src/PageTransition.js
+++ b/src/PageTransition.js
@@ -101,6 +101,9 @@ class PageTransition extends React.Component {
       this.originalScrollTo = window.scrollTo
       this.disableScrolling = false
       window.scrollTo = (...args) => {
+        // If scrolling is disabled, capture the args passed to the scrollTo method
+        // in order to reapply these onEnter. See onEnter for more info about how
+        // this is used.
         if (this.disableScrolling) {
           this.scrollToArgs = args
           return
@@ -197,6 +200,12 @@ class PageTransition extends React.Component {
         showLoading: false,
       },
       () => {
+        // When monkeyPatchScrolling is enabled, reapply the last args passed
+        // to window.scrollTo in order to make sure that the scroll position
+        // is reset before transition. This resolves an issue that primarily
+        // exists within mobile browsers, where the page would transition but
+        // the resulting scrolling position in the page that is being navigated
+        // to would be inconsistent.
         if (
           this.scrollToArgs &&
           monkeyPatchScrolling &&

--- a/src/PageTransition.js
+++ b/src/PageTransition.js
@@ -101,7 +101,10 @@ class PageTransition extends React.Component {
       this.originalScrollTo = window.scrollTo
       this.disableScrolling = false
       window.scrollTo = (...args) => {
-        if (this.disableScrolling) return
+        if (this.disableScrolling) {
+          this.scrollToArgs = args
+          return
+        }
         this.originalScrollTo.apply(window, args)
       }
     }
@@ -184,11 +187,18 @@ class PageTransition extends React.Component {
   }
 
   onEnter() {
+    const { monkeyPatchScrolling } = this.props
+
     // It's safe to reenable scrolling now
     this.disableScrolling = false
     this.setState({
       state: 'enter',
       showLoading: false,
+    }, () => {
+      if (this.scrollToArgs && monkeyPatchScrolling && typeof window !== 'undefined') {
+        window.scrollTo(...this.scrollToArgs)
+        this.scrollToArgs = null
+      }
     })
   }
 


### PR DESCRIPTION
Make call to `window.scroll` `onEnter` after scrolling has been re-enabled. Fixes issue that primarily affects mobile browsers, where the page position is inconsistent between navigations.