### PR TITLE
Handle scrolling to hash on page transition

### DIFF
--- a/src/PageTransition.js
+++ b/src/PageTransition.js
@@ -73,6 +73,21 @@ function makeStateUpdater(state, otherProps) {
   }
 }
 
+function scrollToHash() {
+  // Function lifted from
+  // https://github.com/zeit/next.js/blob/master/packages/next/client/index.js
+  let { hash } = window.location
+  hash = hash && hash.substring(1)
+  if (!hash) return
+
+  const el = document.getElementById(hash)
+  if (!el) return
+
+  // If we call scrollIntoView() in here without a setTimeout
+  // it won't scroll properly.
+  setTimeout(() => el.scrollIntoView(), 0)
+}
+
 class PageTransition extends React.Component {
   constructor(props) {
     super(props)
@@ -122,7 +137,13 @@ class PageTransition extends React.Component {
     const shouldAnimateTransition =
       needsTransition &&
       differentChildrenNeedAnimation(renderedChildren, children)
-    if (isIn && needsTransition && !shouldAnimateTransition) {
+    if (isIn && !needsTransition && state === 'enter') {
+      // We just began transitioning the current page in - this means that the
+      // page now exists in the DOM, and thus it's safe to scroll to the
+      // current hash (if one exists).
+      // See https://github.com/illinois/next-page-transitions/issues/35
+      scrollToHash();
+    } else if (isIn && needsTransition && !shouldAnimateTransition) {
       // We need to update our rendered children, but we shouldn't animate them.
       // This will occur when the key prop on our children stays the same but
       // the children themselves change. This can happen in a lot of cases: HMR,


### PR DESCRIPTION
Browsers only automatically scroll to the URL hash on page load. Since we're doing client-side transitions,  we need to handle that ourselves. Normally, Next.js would take care of that for us: https://github.com/zeit/next.js/blob/0b496a45e85f3c9aa3cf2e77eef10888be5884fc/packages/next/client/index.js#L112. However, since we have transitions, the element with the ID referenced by the hash doesn't actually exist when the page change "completes" from the perspective of Next.js, the automatic scrolling fails. This PR will attempt to scroll to the element referenced by the hash as soon as we know that the page is in the DOM after it starts transitioning in.

Fixes #35.