### PR TITLE
Improve example for usage of key

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ export default class MyApp extends App {
     return (
       <Container>
         <PageTransition timeout={300} classNames="page-transition">
-          <Component {...pageProps} key={router.route} />
+          <Component {...pageProps} key={router.asPath} />
         </PageTransition>
         <style jsx global>{`
           .page-transition-enter {


### PR DESCRIPTION
## What is the problem
Following the read.me I found a problem to generate transitions between the dynamic routes of my projects in this build of [my website](https://5e1f662c109324000829c58e--marcelreis.netlify.com/projects/marcelreis). 

That is caused because `route.route` doesn't change, it still the same if you use a dynamic route, in my case is `/projects/[project]`, so there is no transition. 

## What this pull request do?
It switches the default example for a key to `route.asPath`, this param is based in the next.js query, so it changes for each dynamic route.

## How to test?
I have already have switched the key to `route.asPath` in production